### PR TITLE
Fixes #20: Used a new custom event object for each dispatch

### DIFF
--- a/iron-signals.html
+++ b/iron-signals.html
@@ -53,21 +53,21 @@ of where they are in DOM.
 
   // signal dispatcher
   function notify(name, data) {
-    // convert generic-signal event to named-signal event
-    var signal = new CustomEvent('iron-signal-' + name, {
-      // if signals bubble, it's easy to get confusing duplicates
-      // (1) listen on a container on behalf of local child
-      // (2) some deep child ignores the event and it bubbles
-      //     up to said container
-      // (3) local child event bubbles up to container
-      // also, for performance, we avoid signals flying up the
-      // tree from all over the place
-      bubbles: false,
-      detail: data
-    });
     // dispatch named-signal to all 'signals' instances,
     // only interested listeners will react
     signals.forEach(function(s) {
+      // convert generic-signal event to named-signal event
+      var signal = new CustomEvent('iron-signal-' + name, {
+        // if signals bubble, it's easy to get confusing duplicates
+        // (1) listen on a container on behalf of local child
+        // (2) some deep child ignores the event and it bubbles
+        //     up to said container
+        // (3) local child event bubbles up to container
+        // also, for performance, we avoid signals flying up the
+        // tree from all over the place
+        bubbles: false,
+        detail: data
+      });
       s.dispatchEvent(signal);
     });
   }


### PR DESCRIPTION
Reusing the same CustomEvent object for multiple dispatchEvent calls only works for the first dispatch in Polymer 2. This is probably a CustomElements implementation detail.